### PR TITLE
refactor: jwtToken provider change secret key

### DIFF
--- a/backend/src/main/java/ossproj/demo/util/JwtTokenProvider.java
+++ b/backend/src/main/java/ossproj/demo/util/JwtTokenProvider.java
@@ -29,7 +29,7 @@ public class JwtTokenProvider {
     private final Key key;
 
     // application.yml에서 secret 값을 가져오고 key 저장
-    public JwtTokenProvider(@Value("${DB_SECRET}") String secretKey) {
+    public JwtTokenProvider(@Value("${spring.jwt.secret}") String secretKey) {
         byte[] keyBytes = hexStringToByteArray(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다.

EC2 배포환경에서 로컬에 담긴 secret key 를 받아오지 못해 변수를 수정했습니다.

## 작업내용

jwt secret 포맷 변경

## 체크리스트


### 코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.