### PR TITLE
feat: 유저의 기존 수강과목 저장 테이블 생성 및 등록 API 구현

### DIFF
--- a/backend/src/main/java/ossproj/demo/controller/AlreadyLectureController.java
+++ b/backend/src/main/java/ossproj/demo/controller/AlreadyLectureController.java
@@ -1,0 +1,27 @@
+package ossproj.demo.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import ossproj.demo.dto.request.lecture.AlreadyLectureSaveRequest;
+import ossproj.demo.dto.response.AlreadyLectureSaveResponse;
+import ossproj.demo.dto.response.SuccessResponse;
+import ossproj.demo.exception.Success;
+import ossproj.demo.service.AlreadyLectureService;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/already-lectures")
+public class AlreadyLectureController {
+
+    private final AlreadyLectureService alreadyLectureService;
+
+    @PostMapping("/{userId}")
+    public SuccessResponse<AlreadyLectureSaveResponse> saveUserAlreadyLectures(
+            @PathVariable Long userId,
+            @RequestBody AlreadyLectureSaveRequest saveRequest
+            ) {
+        AlreadyLectureSaveResponse alreadyLectureSaveResponse = alreadyLectureService.saveUserAlreadyLecture(userId, saveRequest);
+        return SuccessResponse.success(Success.POST_ALREADYLECTURES_SUCCESS, alreadyLectureSaveResponse);
+    }
+
+}

--- a/backend/src/main/java/ossproj/demo/dto/request/lecture/AlreadyLectureSaveRequest.java
+++ b/backend/src/main/java/ossproj/demo/dto/request/lecture/AlreadyLectureSaveRequest.java
@@ -1,0 +1,19 @@
+package ossproj.demo.dto.request.lecture;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class AlreadyLectureSaveRequest {
+    private int alFirstId;
+    private int alSecondId;
+    private int alThirdId;
+    private int alFourthId;
+    private int alFifthId;
+    private int alSixthId;
+}

--- a/backend/src/main/java/ossproj/demo/dto/response/AlreadyLectureSaveResponse.java
+++ b/backend/src/main/java/ossproj/demo/dto/response/AlreadyLectureSaveResponse.java
@@ -1,0 +1,13 @@
+package ossproj.demo.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlreadyLectureSaveResponse {
+    private Long AlreadyLectureId;
+
+}

--- a/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
+++ b/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
@@ -1,0 +1,40 @@
+package ossproj.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity(name="already_lectures")
+
+public class AlreadyLecture {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "already_lecture_id", nullable = false)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Column(nullable = false)
+    private String alFirstId;
+
+    @Column(nullable = false)
+    private String alSecondId;
+
+    @Column(nullable = false)
+    private String alThirdId;
+
+    @Column(nullable = false)
+    private String alFourthId;
+
+    @Column(nullable = false)
+    private String alFifthId;
+
+    @Column(nullable = false)
+    private String alSixthId;
+
+}

--- a/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
+++ b/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
@@ -4,11 +4,12 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ossproj.demo.dto.response.AlreadyLectureSaveResponse;
 
 @Getter
 @NoArgsConstructor
 @Entity(name="already_lectures")
-public class AlreadyLecture {
+public class AlreadyLecture extends AlreadyLectureSaveResponse {
 
     @Id
     @GeneratedValue

--- a/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
+++ b/backend/src/main/java/ossproj/demo/entity/AlreadyLecture.java
@@ -1,13 +1,13 @@
 package ossproj.demo.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @Entity(name="already_lectures")
-
 public class AlreadyLecture {
 
     @Id
@@ -20,21 +20,32 @@ public class AlreadyLecture {
     private Users user;
 
     @Column(nullable = false)
-    private String alFirstId;
+    private int alFirstId;
 
     @Column(nullable = false)
-    private String alSecondId;
+    private int alSecondId;
 
     @Column(nullable = false)
-    private String alThirdId;
+    private int alThirdId;
 
     @Column(nullable = false)
-    private String alFourthId;
+    private int alFourthId;
 
     @Column(nullable = false)
-    private String alFifthId;
+    private int alFifthId;
 
     @Column(nullable = false)
-    private String alSixthId;
+    private int alSixthId;
 
+
+    @Builder
+    public AlreadyLecture(Users user, int alFirstId, int alSecondId, int alThirdId, int alFourthId, int alFifthId, int alSixthId) {
+        this.user = user;
+        this.alFirstId = alFirstId;
+        this.alSecondId = alSecondId;
+        this.alThirdId = alThirdId;
+        this.alFourthId = alFourthId;
+        this.alFifthId = alFifthId;
+        this.alSixthId = alSixthId;
+    }
 }

--- a/backend/src/main/java/ossproj/demo/exception/Success.java
+++ b/backend/src/main/java/ossproj/demo/exception/Success.java
@@ -17,6 +17,7 @@ public enum Success {
     /**
      * STATUS CODE : 201 OK
      */
+    POST_ALREADYLECTURES_SUCCESS(HttpStatus.CREATED,"유저 기존 수강 과목 등록 성공"),
     POST_SIGNUP_SUCCESS(HttpStatus.CREATED,"유저 생성 성공");
 
 

--- a/backend/src/main/java/ossproj/demo/repository/AlreadyLectureRepository.java
+++ b/backend/src/main/java/ossproj/demo/repository/AlreadyLectureRepository.java
@@ -1,0 +1,9 @@
+package ossproj.demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ossproj.demo.entity.AlreadyLecture;
+
+public interface AlreadyLectureRepository extends JpaRepository<AlreadyLecture, Long> {
+
+
+}

--- a/backend/src/main/java/ossproj/demo/service/AlreadyLectureService.java
+++ b/backend/src/main/java/ossproj/demo/service/AlreadyLectureService.java
@@ -1,0 +1,38 @@
+package ossproj.demo.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ossproj.demo.dto.request.lecture.AlreadyLectureSaveRequest;
+import ossproj.demo.dto.response.AlreadyLectureSaveResponse;
+import ossproj.demo.entity.AlreadyLecture;
+import ossproj.demo.entity.Users;
+import ossproj.demo.repository.AlreadyLectureRepository;
+import ossproj.demo.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AlreadyLectureService {
+
+    private final UserRepository userRepository;
+    private final AlreadyLectureRepository alreadyLectureRepository;
+
+    public AlreadyLectureSaveResponse saveUserAlreadyLecture(Long userId, AlreadyLectureSaveRequest saveRequest) {
+        Users user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+
+        AlreadyLecture generateAlreadyLecture = AlreadyLecture.builder()
+                .user(user)
+                .alFirstId(saveRequest.getAlFirstId())
+                .alSecondId(saveRequest.getAlSecondId())
+                .alThirdId(saveRequest.getAlThirdId())
+                .alFourthId(saveRequest.getAlFourthId())
+                .alFifthId(saveRequest.getAlFifthId())
+                .alSixthId(saveRequest.getAlSixthId())
+                .build();
+
+        return alreadyLectureRepository.save(generateAlreadyLecture);
+    }
+}


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다.

- 학생의 기존 수강 과목을 6개를 저장하는 엔티티를 생성했습니다. 

## 배경

- 학생의 기존 수강과목을 등록해, ML 서버에서 데이터 트레이닝시 과목을 고려한 추천을 하기 위함입니다.

## 작업내용

1. 엔티티 생성
2. 기존 수강과목 API 추가

## 체크리스트


### 코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.