### PR TITLE
refactor: 로그인시 해당 유저 id, 전공 id 반환하도록 수정

### DIFF
--- a/backend/src/main/java/ossproj/demo/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/ossproj/demo/config/JwtAuthenticationFilter.java
@@ -36,6 +36,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+//            System.out.println("authentication.getName() = " + authentication.getName());
         }
         chain.doFilter(request, response);
     }

--- a/backend/src/main/java/ossproj/demo/controller/UserController.java
+++ b/backend/src/main/java/ossproj/demo/controller/UserController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import ossproj.demo.dto.JwtToken;
 import ossproj.demo.dto.request.auth.LoginRequest;
 import ossproj.demo.dto.request.auth.SignupRequest;
+import ossproj.demo.dto.response.LectureResponse;
+import ossproj.demo.dto.response.LoginResponse;
 import ossproj.demo.dto.response.SignupResponse;
 import ossproj.demo.dto.response.SuccessResponse;
 import ossproj.demo.exception.Success;
@@ -31,13 +33,11 @@ public class UserController {
 
 
     @PostMapping("/login")
-    public JwtToken login(@RequestBody LoginRequest loginRequest) {
+    public SuccessResponse<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
         String studentId = loginRequest.getStudentNumber();
         String password = loginRequest.getPassword();
-        JwtToken jwtToken = userService.login(studentId, password);
-        log.info("requset studentId = {} , password = {}", studentId, password);
-        log.info("jwtToken accessToken = {}, refreshToken = {}", jwtToken.getAccessToken(), jwtToken.getRefreshToken());
-        return jwtToken;
+        LoginResponse login = userService.login(studentId, password);
+        return SuccessResponse.success(Success.POST_LOGIN_SUCCESS, login);
     }
 
     @PostMapping("/test")

--- a/backend/src/main/java/ossproj/demo/dto/JwtToken.java
+++ b/backend/src/main/java/ossproj/demo/dto/JwtToken.java
@@ -11,4 +11,5 @@ public class JwtToken {
     private String grantType;
     private String accessToken;
     private String refreshToken;
+
 }

--- a/backend/src/main/java/ossproj/demo/dto/response/LoginResponse.java
+++ b/backend/src/main/java/ossproj/demo/dto/response/LoginResponse.java
@@ -1,0 +1,17 @@
+package ossproj.demo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ossproj.demo.dto.JwtToken;
+import ossproj.demo.entity.Major;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Getter
+public class LoginResponse {
+    private JwtToken jwtToken;
+    private Long user_id;
+    private Long major_id;
+
+}

--- a/backend/src/main/java/ossproj/demo/exception/Success.java
+++ b/backend/src/main/java/ossproj/demo/exception/Success.java
@@ -18,7 +18,8 @@ public enum Success {
      * STATUS CODE : 201 OK
      */
     POST_ALREADYLECTURES_SUCCESS(HttpStatus.CREATED,"유저 기존 수강 과목 등록 성공"),
-    POST_SIGNUP_SUCCESS(HttpStatus.CREATED,"유저 생성 성공");
+    POST_SIGNUP_SUCCESS(HttpStatus.CREATED,"유저 생성 성공"),
+    POST_LOGIN_SUCCESS(HttpStatus.CREATED,"로그인 성공");
 
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/ossproj/demo/repository/MajorRepository.java
+++ b/backend/src/main/java/ossproj/demo/repository/MajorRepository.java
@@ -12,4 +12,5 @@ public interface MajorRepository extends JpaRepository<Major, Long> {
 
     @Override
     Optional<Major> findById(Long majorId);
+
 }

--- a/backend/src/main/java/ossproj/demo/repository/UserRepository.java
+++ b/backend/src/main/java/ossproj/demo/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package ossproj.demo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import ossproj.demo.entity.Major;
 import ossproj.demo.entity.Users;
 
 import java.util.Optional;
@@ -13,6 +15,12 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUsername(String username);
 
     Optional<Users> findByStudentNumber(String studentNumber);
+
+    @Query("SELECT u.id FROM Users u WHERE u.studentNumber = ?1")
+    Long findIdByStudentNumber(String studentNumber);
+
+    @Query("SELECT u.major FROM Users u WHERE u.studentNumber = ?1")
+    Major findMajorByStudentNumber(String studentNumber);
 
     boolean existsByStudentNumber(String studentNumber);
 

--- a/backend/src/main/java/ossproj/demo/service/AlreadyLectureService.java
+++ b/backend/src/main/java/ossproj/demo/service/AlreadyLectureService.java
@@ -22,7 +22,7 @@ public class AlreadyLectureService {
 
     public AlreadyLectureSaveResponse saveUserAlreadyLecture(Long userId, AlreadyLectureSaveRequest saveRequest) {
         Users user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
-
+        System.out.println("user = " + user);
         AlreadyLecture generateAlreadyLecture = AlreadyLecture.builder()
                 .user(user)
                 .alFirstLectureName(saveRequest.getAlFirstLectureName())

--- a/backend/src/main/java/ossproj/demo/service/CustomUserDetailService.java
+++ b/backend/src/main/java/ossproj/demo/service/CustomUserDetailService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String studentNumber) throws UsernameNotFoundException {
         Optional<Users> findOne = userRepository.findByStudentNumber(studentNumber);
-        Users user =findOne.orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
+        Users user = findOne.orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
         return User.builder()
                 .username(user.getStudentNumber())
                 .password(user.getPassword())

--- a/backend/src/main/java/ossproj/demo/service/UserService.java
+++ b/backend/src/main/java/ossproj/demo/service/UserService.java
@@ -1,11 +1,11 @@
 package ossproj.demo.service;
 
-import ossproj.demo.dto.JwtToken;
 import ossproj.demo.dto.request.auth.SignupRequest;
+import ossproj.demo.dto.response.LoginResponse;
 import ossproj.demo.dto.response.SignupResponse;
 
 public interface UserService {
-    JwtToken login(String studentId, String password);
+    LoginResponse login(String studentId, String password);
 
     SignupResponse signup(SignupRequest signupRequest);
 }

--- a/backend/src/main/java/ossproj/demo/service/UserServiceImpl.java
+++ b/backend/src/main/java/ossproj/demo/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ossproj.demo.dto.JwtToken;
 import ossproj.demo.dto.request.auth.SignupRequest;
+import ossproj.demo.dto.response.LoginResponse;
 import ossproj.demo.dto.response.SignupResponse;
 import ossproj.demo.entity.Major;
 import ossproj.demo.entity.Users;
@@ -33,12 +34,16 @@ public class UserServiceImpl implements UserService {
 
 
     @Transactional
-    public JwtToken login(String studentId, String password) {
+    public LoginResponse login(String studentId, String password) {
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(studentId, password);
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-        return jwtTokenProvider.generateToken(authentication);
+        String studentNumber = authentication.getName();
+        Long userId = userRepository.findIdByStudentNumber(studentNumber);
+        Major userMajor = userRepository.findMajorByStudentNumber(studentNumber);
+        Long majorId = userMajor.getMajorId();
+        JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+        return new LoginResponse(jwtToken, userId,majorId);
     }
 
     @Transactional

--- a/backend/src/main/java/ossproj/demo/util/JwtTokenProvider.java
+++ b/backend/src/main/java/ossproj/demo/util/JwtTokenProvider.java
@@ -52,6 +52,7 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", authorities)
+
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다.

해당 accessToken에 담긴 유저와 전공 정보 반환하도록 수정하였습니다.

## 작업내용
<img width="647" alt="스크린샷 2023-12-11 오후 6 53 46" src="https://github.com/CSID-DGU/2023-2-OSSProj-TurtleNeck-9/assets/89504367/0aca30d1-f41d-4655-801d-f86b73b167db">


## 체크리스트

### 코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.